### PR TITLE
Remove Firebase-based push notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,6 @@ VITE_JWT_SECRET=<your secret key>
 VITE_AZURE_STORAGE_ACCOUNT=<your storage account>
 VITE_AZURE_STORAGE_CONTAINER=<your container name>
 VITE_AZURE_STORAGE_SAS=<your SAS token>
-VITE_FIREBASE_API_KEY=<firebase api key>
-VITE_FIREBASE_AUTH_DOMAIN=<firebase auth domain>
-VITE_FIREBASE_PROJECT_ID=<firebase project id>
-VITE_FIREBASE_MESSAGING_SENDER_ID=<firebase sender id>
-VITE_FIREBASE_APP_ID=<firebase app id>
-VITE_FIREBASE_VAPID_KEY=<public vapid key>
-FIREBASE_SERVICE_ACCOUNT=<service account JSON>
 ```
 
 The app requires `VITE_JWT_SECRET` for authentication tokens. Azure Storage variables are optional but enable media uploads if provided.

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,85 +1,13 @@
 import express from 'express';
-import admin from 'firebase-admin';
-import fs from 'fs';
-import cron from 'node-cron';
-
+// Firebase push notifications disabled
 const app = express();
 const PORT = process.env.PORT || 4000;
-
-const TOKENS_FILE = new URL('./push-tokens.json', import.meta.url).pathname;
-let pushTokens = [];
-
-function loadTokens() {
-  try {
-    const data = fs.readFileSync(TOKENS_FILE, 'utf8');
-    pushTokens = JSON.parse(data);
-  } catch {
-    pushTokens = [];
-  }
-}
-
-function saveTokens() {
-  fs.writeFileSync(TOKENS_FILE, JSON.stringify(pushTokens, null, 2));
-}
-
-loadTokens();
-
-if (process.env.FIREBASE_SERVICE_ACCOUNT) {
-  const credentials = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT);
-  admin.initializeApp({ credential: admin.credential.cert(credentials) });
-}
-
+// Push token management disabled
 app.use(express.json());
-
-app.post('/api/push/register', (req, res) => {
-  const { userId, token } = req.body;
-  if (!userId || !token) {
-    return res.status(400).json({ message: 'Missing parameters' });
-  }
-  if (!pushTokens.find(t => t.token === token)) {
-    pushTokens.push({ userId, token });
-    saveTokens();
-  }
-  res.json({ status: 'registered' });
-});
-
-app.post('/api/push/unregister', (req, res) => {
-  const { token } = req.body;
-  if (!token) {
-    return res.status(400).json({ message: 'Missing parameters' });
-  }
-  pushTokens = pushTokens.filter(t => t.token !== token);
-  saveTokens();
-  res.json({ status: 'unregistered' });
-});
-
-async function sendPushNotification(token, payload) {
-  if (!admin.apps.length) return;
-  try {
-    await admin.messaging().send({ token, notification: payload });
-  } catch (err) {
-    console.error('Failed to send push notification', err);
-  }
-}
-
-async function sendDailyReminders() {
-  const notification = {
-    title: 'Log Your Meals! \u{1F37D}',
-    body: "Don't forget to track your daily consumption!",
-  };
-  for (const { token } of pushTokens) {
-    await sendPushNotification(token, notification);
-  }
-}
-
-cron.schedule('0 19 * * *', () => {
-  sendDailyReminders();
-});
-
+// Push registration endpoints and cron job removed
 app.get('/api/health', (req, res) => {
   res.json({ status: 'ok' });
 });
-
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });

--- a/frontend/src/lib/notifications.ts
+++ b/frontend/src/lib/notifications.ts
@@ -1,17 +1,5 @@
 // Notification utilities for the app
-import { initializeApp } from 'firebase/app';
-import { getMessaging, getToken as getFCMToken } from 'firebase/messaging';
-import { apiClient } from './api-client';
 
-const firebaseApp = initializeApp({
-  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
-  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
-  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
-  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
-  appId: import.meta.env.VITE_FIREBASE_APP_ID,
-});
-
-const messaging = getMessaging(firebaseApp);
 export interface NotificationPreferences {
   enableNotifications: boolean;
   dailyReminders: boolean;
@@ -22,37 +10,6 @@ export interface NotificationPreferences {
 
 export class NotificationService {
   private static readonly STORAGE_KEY = 'notification_preferences';
-  private static readonly TOKEN_KEY = 'push_token';
-
-  private static async getPushToken(): Promise<string | null> {
-    try {
-      const token = await getFCMToken(messaging, {
-        vapidKey: import.meta.env.VITE_FIREBASE_VAPID_KEY,
-      });
-      return token;
-    } catch (err) {
-      console.error('Failed to get FCM token', err);
-      return null;
-    }
-  }
-
-  static async enablePush(userId: string): Promise<void> {
-    const allowed = await this.requestPermission();
-    if (!allowed) return;
-    const token = await this.getPushToken();
-    if (token) {
-      localStorage.setItem(this.TOKEN_KEY, token);
-      await apiClient.registerPushToken(userId, token);
-    }
-  }
-
-  static async disablePush(): Promise<void> {
-    const token = localStorage.getItem(this.TOKEN_KEY);
-    if (token) {
-      await apiClient.unregisterPushToken(token);
-      localStorage.removeItem(this.TOKEN_KEY);
-    }
-  }
 
   // Request notification permission
   static async requestPermission(): Promise<boolean> {


### PR DESCRIPTION
## Summary
- drop all Firebase token logic from notification utility
- strip Firebase environment variables from docs
- simplify backend server by removing push token endpoints

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_68841e832a98832fa6c50c6b39cbd5f0