### PR TITLE
Add dotenv support for backend

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -13,4 +13,15 @@ npm start
 
 The server listens on `PORT` (defaults to `4000`) and uses the `DATABASE_URL` environment variable to connect to PostgreSQL. It also exposes a health endpoint at `/api/health` that returns `{ status: 'ok' }`.
 
+### Environment variables
+
+Create a `.env` file in this directory with at least the following variables:
+
+```env
+DATABASE_URL=postgres://snackuser:snackpass@localhost:5432/snacktrack
+PORT=4000
+```
+
+These values are loaded automatically at runtime using `dotenv`.
+
 Future API routes should be added to `server.js`.

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,6 +1,9 @@
 import pkg from 'pg';
 const { Pool } = pkg;
 import crypto from 'node:crypto';
+import dotenv from 'dotenv';
+
+dotenv.config();
 
 const connectionString =
   process.env.DATABASE_URL ||

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "express": "^4.19.2",
     "multer": "^2.0.2",
-    "pg": "^8.11.5"
+    "pg": "^8.11.5",
+    "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "nodemon": "^3.0.3"

--- a/backend/server.js
+++ b/backend/server.js
@@ -4,7 +4,10 @@ import fs from 'fs';
 import path from 'path';
 import { spawn } from 'child_process';
 import crypto from 'node:crypto';
+import dotenv from 'dotenv';
 import { pool, initDb } from './db.js';
+
+dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 4000;


### PR DESCRIPTION
## Summary
- add `dotenv` dependency for backend
- load `.env` in `server.js` and `db.js`
- document required environment variables in backend README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68874b893b94832fbeeba132d689a221