### PR TITLE
Fix login data mapping and first login welcome

### DIFF
--- a/frontend/src/lib/local-db.ts
+++ b/frontend/src/lib/local-db.ts
@@ -36,6 +36,20 @@ export interface Reward {
   isActive: boolean;
 }
 
+function toCamelCase(obj: any): any {
+  if (Array.isArray(obj)) {
+    return obj.map((v) => toCamelCase(v));
+  }
+  if (obj && typeof obj === 'object') {
+    return Object.entries(obj).reduce((acc: any, [key, value]) => {
+      const camelKey = key.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+      acc[camelKey] = toCamelCase(value);
+      return acc;
+    }, {});
+  }
+  return obj;
+}
+
 async function request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
   const res = await fetch(`/api${endpoint}`, {
     headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
@@ -44,7 +58,8 @@ async function request<T>(endpoint: string, options: RequestInit = {}): Promise<
   if (!res.ok) {
     throw new Error(`Request failed: ${res.status}`);
   }
-  return res.json();
+  const data = await res.json();
+  return toCamelCase(data) as T;
 }
 
 export const localDbOperations = {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -33,10 +33,15 @@ const Dashboard = () => {
   const [dailyProgress, setDailyProgress] = useState<number[]>(
     Array(7).fill(0),
   );
+  const [firstLogin, setFirstLogin] = useState(false);
 
   useEffect(() => {
     if (!localStorage.getItem("onboardingCompleted")) {
       navigate("/onboarding", { replace: true });
+    }
+    if (localStorage.getItem("firstLogin")) {
+      setFirstLogin(true);
+      localStorage.removeItem("firstLogin");
     }
   }, [navigate]);
 
@@ -143,7 +148,7 @@ const Dashboard = () => {
         {/* Welcome Section */}
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-gradient mb-2">
-            Welcome back, {user?.firstName || "there"}! 👋
+            {firstLogin ? "Welcome" : "Welcome back"}, {user?.firstName || "there"}! 👋
           </h1>
           <p className="text-muted-foreground">
             Ready to log another delicious Naija meal?

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -100,6 +100,9 @@ const Register = () => {
         const token = await authUtils.generateToken(user);
         authUtils.setAuthToken(token);
 
+        // Mark first login so the dashboard can greet the user properly
+        localStorage.setItem("firstLogin", "true");
+
         localStorage.removeItem("registerForm"); // Clear saved form on success
 
         toast({


### PR DESCRIPTION
## Summary
- normalize API responses to camelCase
- flag first login after registration
- show `Welcome` on first dashboard visit

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6887f1ff06d8832fbd2c02fdf55e6dff