### PR TITLE
Add Azure backend deployment workflow

### DIFF
--- a/.github/workflows/azure-backend-webapp.yml
+++ b/.github/workflows/azure-backend-webapp.yml
@@ -1,0 +1,38 @@
+name: Deploy Backend to Azure Web App
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    env:
+      AZURE_WEBAPP_NAME: <your-backend-app>
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          npm install
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Deploy to Azure Web App
+        uses: azure/webapps-deploy@v2
+        with:
+          app-name: ${{ env.AZURE_WEBAPP_NAME }}
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
+          package: .
+

--- a/README.md
+++ b/README.md
@@ -99,3 +99,13 @@ This project is built with:
 ### Logging meals
 
 On the log consumption page you can switch between **Manual Entry** and **AI Capture**. Manual entry only shows the meal form, while AI Capture also records audio or video which is transcribed using Whisper.
+
+### Deploying to Azure
+
+The frontend is published using **Azure Static Web Apps** (`.github/workflows/azure-static-web-apps-witty-stone-092422e03.yml`). To deploy the Express backend on **Azure Web App**, a workflow is provided at `.github/workflows/azure-backend-webapp.yml`.
+
+1. Create an Azure Web App for the backend and download its publish profile. Add the profile as the repository secret `AZURE_WEBAPP_PUBLISH_PROFILE`.
+2. Set the `AZURE_WEBAPP_NAME` environment variable in the workflow (replace `<your-backend-app>` with your actual app name).
+3. The workflow installs Node dependencies and then runs `pip install -r requirements.txt` so the Python Whisper dependencies are available during deployment.
+
+Requests from the static site to `/api` are proxied to the backend using `frontend/staticwebapp.config.json`. Update this file with your backend domain so the frontend can communicate with the API once deployed.

--- a/frontend/staticwebapp.config.json
+++ b/frontend/staticwebapp.config.json
@@ -1,0 +1,8 @@
+{
+  "routes": [
+    {
+      "route": "/api/*",
+      "rewrite": "https://<your-backend-app>.azurewebsites.net/api/:*"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add workflow for deploying the Node/Python backend to Azure Web App
- proxy `/api` requests from Static Web App to the backend
- document deployment steps in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6888cf8a5120832fb76055d6c7f68348