### PR TITLE
Fix proxy route

### DIFF
--- a/BACKEND.md
+++ b/BACKEND.md
@@ -17,12 +17,12 @@ npm start
 
 If a `.venv` directory exists, the server uses its Python interpreter when spawning the transcription script.
 
-The server listens on `PORT` (defaults to `4000`) and uses the `DB_*` environment variables to connect to PostgreSQL. It also exposes a health endpoint at `/api/health` that returns `{ status: 'ok' }`.
-During development the frontend's Vite server proxies `/api` requests to this port, so make sure it is running before interacting with the app.
+The server listens on `PORT` (defaults to `4000`) and uses the `DB_*` environment variables to connect to PostgreSQL. It exposes a simple health endpoint at `/api/health` that returns `{ status: 'ok' }` and an informational message at `/api`.
+During development the frontend's Vite server proxies `/api` requests to this port, so make sure the backend is running before interacting with the app.
 
 ### Environment variables
 
-Copy the `.env.example` file from the repository root to `.env` in this directory and define at least the following variables:
+Create a `.env` file in this directory for local development and define at least the following variables. In production set them as environment variables (e.g. Azure App Settings):
 
 ```env
 DB_HOST=localhost
@@ -33,7 +33,7 @@ DB_NAME=snacktrack
 PORT=4000
 ```
 
-These values are loaded automatically at runtime using `dotenv`.
+If a `.env` file is present these values are loaded with `dotenv`.
 When connecting to a hosted database (e.g. Render or Heroku), provide the host, port, username and password from your provider. TLS is automatically enabled for any host that is not `localhost`.
 
 Future API routes should be added to `server.js`.

--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ The server automatically creates an `uploads` folder for media files if it does 
 
 ### Environment Variables
 
-Copy `.env.example` to `.env` in the project root (or use your hosting provider's configuration) and define the following variables:
+Create a `.env` file in the project root for local development and define the following variables. In production, set them in your hosting provider's configuration (for Azure use **App Settings**):
 
 VITE_JWT_SECRET=<your secret key>
+VITE_API_BASE_URL=<deployed backend URL>
 DB_HOST=localhost
 DB_PORT=5432
 DB_USER=snackuser
@@ -57,6 +58,10 @@ AZURE_STORAGE_CONNECTION_STRING=<your connection string>
 AZURE_AUDIO_CONTAINER=audio-logs
 AZURE_MEDIA_CONTAINER=media-logs
 ```
+
+`VITE_API_BASE_URL` is optional when the frontend and backend are served from the same domain. Set it to your backend URL when running the frontend locally against a remote API.
+
+The server reads these values from environment variables at runtime. For Azure deployments define them in **App Settings** so `process.env` contains the required values.
 
 The app requires `VITE_JWT_SECRET` for authentication tokens. The `DB_*` variables define the PostgreSQL connection used by the backend. When deploying on services like Render, use the host, port, username and password provided by the platform. SSL is automatically enabled for any host that is not `localhost`.
 
@@ -109,3 +114,4 @@ The frontend is published using **Azure Static Web Apps** (`.github/workflows/az
 3. The workflow installs Node dependencies and then runs `python setup_env.py` to create a `.venv` folder with the Python Whisper dependencies before packaging the app.
 
 Requests from the static site to `/api` are proxied to the backend using `frontend/staticwebapp.config.json`. Update this file with your backend domain so the frontend can communicate with the API once deployed.
+If the frontend and backend appear disconnected, verify that this file points to your deployed backend's URL.

--- a/db.js
+++ b/db.js
@@ -1,12 +1,18 @@
 import pkg from 'pg';
 const { Pool } = pkg;
 import crypto from 'node:crypto';
+import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import dotenv from 'dotenv';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-dotenv.config({ path: path.join(__dirname, '.env') });
+const envPath = path.join(__dirname, '.env');
+if (fs.existsSync(envPath)) {
+  dotenv.config({ path: envPath });
+} else {
+  dotenv.config();
+}
 
 const isLocal =
   process.env.DB_HOST?.includes('localhost') ||

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,3 @@
 VITE_JWT_SECRET=your_jwt_secret_here
+# Uncomment and set this when connecting to a remote backend during local development
+# VITE_API_BASE_URL=

--- a/frontend/src/lib/local-db.ts
+++ b/frontend/src/lib/local-db.ts
@@ -50,8 +50,16 @@ function toCamelCase(obj: any): any {
   return obj;
 }
 
+const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
+
+function buildUrl(endpoint: string): string {
+  if (!API_BASE) return `/api${endpoint}`;
+  const base = API_BASE.replace(/\/$/, '');
+  return `${base}/api${endpoint}`;
+}
+
 async function request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
-  const res = await fetch(`/api${endpoint}`, {
+  const res = await fetch(buildUrl(endpoint), {
     headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
     ...options
   });

--- a/frontend/staticwebapp.config.json
+++ b/frontend/staticwebapp.config.json
@@ -2,7 +2,7 @@
   "routes": [
     {
       "route": "/api/*",
-      "rewrite": "https://snackstrackbackendv21a-c0eyere2dbfthyhn.southafricanorth-01.azurewebsites.net/api/:*"
+      "rewrite": "https://snacksappbackendv2b-b0erbpa2dmh6brg0.southafricanorth-01.azurewebsites.net/api/:*"
     }
   ]
 }

--- a/server.js
+++ b/server.js
@@ -10,7 +10,12 @@ import { BlobServiceClient } from '@azure/storage-blob';
 import { pool, initDb } from './db.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-dotenv.config({ path: path.join(__dirname, '.env') });
+const envPath = path.join(__dirname, '.env');
+if (fs.existsSync(envPath)) {
+  dotenv.config({ path: envPath });
+} else {
+  dotenv.config();
+}
 
 const blobServiceClient = process.env.AZURE_STORAGE_CONNECTION_STRING
   ? BlobServiceClient.fromConnectionString(
@@ -73,7 +78,7 @@ app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok' });
 });
 
-app.get('/', (_req, res) => {
+app.get('/api', (_req, res) => {
   res.send('Backend API is running 🎉');
 });
 


### PR DESCRIPTION
## Summary
- update frontend `staticwebapp.config.json` with the new backend domain
- allow overriding the API base URL for local dev or separate deployments
- document optional `VITE_API_BASE_URL` in README and `.env`

## Testing
- `npm test --silent`
- `pytest -q`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_68890fd3c944832f9fba865d4ad9cdb0