### PR TITLE
Fix static web app API rewrite

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
 VITE_JWT_SECRET=your_jwt_secret_here
-VITE_API_BASE_URL=https://snacksappbackendv2b-b0erbpa2dmh6brg0.southafricanorth-01.azurewebsites.net/api
+VITE_API_BASE_URL=https://snacksappbackendv2b-b0erbpa2dmh6brg0.southafricanorth-01.azurewebsites.net

--- a/frontend/staticwebapp.config.json
+++ b/frontend/staticwebapp.config.json
@@ -2,7 +2,7 @@
   "routes": [
     {
       "route": "/api/*",
-      "rewrite": "https://snacksappbackendv2b-b0erbpa2dmh6brg0.southafricanorth-01.azurewebsites.net/api/:*"
+      "rewrite": "https://snacksappbackendv2b-b0erbpa2dmh6brg0.southafricanorth-01.azurewebsites.net/api/:path*"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- update staticwebapp.config.json to use `:path*`
- remove `/api` from `VITE_API_BASE_URL` in `.env`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6889f8603cc8832fb5c56cba9dfafbd1