### PR TITLE
Add backend CORS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ VITE_JWT_SECRET=<your secret key>
 VITE_API_BASE_URL=<deployed backend URL>
 # Use only the domain, not the `/api` path. The app will automatically
 # append `/api` when contacting the backend.
+CORS_ORIGIN=<allowed domains>
 DB_HOST=localhost
 DB_PORT=5432
 DB_USER=snackuser
@@ -62,6 +63,7 @@ AZURE_MEDIA_CONTAINER=media-logs
 ```
 
 `VITE_API_BASE_URL` is optional when the frontend and backend are served from the same domain. Set it to your backend URL when running the frontend locally against a remote API.
+`CORS_ORIGIN` specifies which domains may access the API. Provide your deployed frontend's URL (or a comma-separated list) so browsers can make cross-origin requests.
 
 The server reads these values from environment variables at runtime. For Azure deployments define them in **App Settings** so `process.env` contains the required values.
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev:backend": "nodemon server.js"
   },
   "dependencies": {
+    "@azure/storage-blob": "^12.15.0",
     "@capacitor/android": "^7.4.2",
     "@capacitor/cli": "^7.4.2",
     "@capacitor/core": "^7.4.2",
@@ -49,11 +50,16 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
+    "cors": "^2.8.5",
     "date-fns": "^3.6.0",
+    "dotenv": "^16.4.5",
     "embla-carousel-react": "^8.3.0",
+    "express": "^4.19.2",
     "input-otp": "^1.2.4",
     "lovable-tagger": "^1.1.8",
     "lucide-react": "^0.462.0",
+    "multer": "^2.0.2",
+    "pg": "^8.11.5",
     "react": "^18.3.1",
     "react-activity-calendar": "^2.7.13",
     "react-day-picker": "^8.10.1",
@@ -66,12 +72,7 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
-    "zod": "^3.23.8",
-    "express": "^4.19.2",
-    "multer": "^2.0.2",
-    "pg": "^8.11.5",
-    "dotenv": "^16.4.5",
-    "@azure/storage-blob": "^12.15.0"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",
@@ -85,11 +86,11 @@
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.9.0",
+    "nodemon": "^3.0.3",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1",
-    "nodemon": "^3.0.3"
+    "vite": "^5.4.1"
   }
 }

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ import { spawn } from 'child_process';
 import crypto from 'node:crypto';
 import { fileURLToPath } from 'url';
 import dotenv from 'dotenv';
+import cors from 'cors';
 import { BlobServiceClient } from '@azure/storage-blob';
 import { pool, initDb } from './db.js';
 
@@ -63,6 +64,10 @@ try {
   dbReady = false;
 }
 
+const allowedOrigins = process.env.CORS_ORIGIN
+  ? process.env.CORS_ORIGIN.split(',').map((o) => o.trim())
+  : '*';
+app.use(cors({ origin: allowedOrigins }));
 app.use(express.json());
 app.use('/uploads', express.static(path.join(process.cwd(), 'uploads')));
 


### PR DESCRIPTION
## Summary
- import `cors` and enable it in `server.js`
- document `CORS_ORIGIN` environment variable
- include `cors` dependency

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688a05cf3644832f88c85a15d2981a08