### PR TITLE
Add Azure Speech transcription support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ DB_NAME=snacktrack
 AZURE_STORAGE_CONNECTION_STRING=<your connection string>
 AZURE_AUDIO_CONTAINER=audio-logs
 AZURE_MEDIA_CONTAINER=media-logs
+AZURE_SPEECH_KEY=<your speech key>
+AZURE_SPEECH_REGION=<your speech region>
 ```
 
 `VITE_API_BASE_URL` is optional when the frontend and backend are served from the same domain. Set it to your backend URL when running the frontend locally against a remote API.
@@ -107,7 +109,7 @@ This project is built with:
 
 ### Logging meals
 
-On the log consumption page you can switch between **Manual Entry** and **AI Capture**. Manual entry only shows the meal form, while AI Capture also records audio or video which is transcribed using Whisper.
+On the log consumption page you can switch between **Manual Entry** and **AI Capture**. Manual entry only shows the meal form, while AI Capture also records audio or video which is transcribed using Azure Speech to Text when credentials are provided (otherwise Whisper is used).
 
 ### Deploying to Azure
 
@@ -115,7 +117,9 @@ You can publish the frontend using **Azure Static Web Apps** and deploy the Expr
 
 Requests from the static site to `/api` are proxied to the backend using `frontend/staticwebapp.config.json`. Update this file with your backend domain so the frontend can communicate with the API once deployed. If the frontend and backend appear disconnected, verify that this file points to your deployed backend's URL.
 
-The `/api/transcribe` endpoint depends on Python 3, `openai-whisper`, and `ffmpeg`.
-When deploying the backend to Azure Web App, make sure these dependencies are
-installed (for example by running `python setup_env.py`). Without them the
-transcription step will fail and AI Capture will display an error.
+The `/api/transcribe` endpoint depends on Python 3, `ffmpeg` and either the
+`openai-whisper` or `azure-cognitiveservices-speech` library. When
+`AZURE_SPEECH_KEY` and `AZURE_SPEECH_REGION` are defined the server uses Azure
+Speech to Text; otherwise it falls back to Whisper. Ensure these dependencies are
+installed (run `python setup_env.py`) before deploying the backend. Without
+them the transcription step will fail and AI Capture will display an error.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 openai-whisper
 ffmpeg-python
+azure-cognitiveservices-speech

--- a/transcribe.py
+++ b/transcribe.py
@@ -9,6 +9,7 @@ import platform
 import ctypes.util
 import whisper
 import ffmpeg
+import azure.cognitiveservices.speech as speechsdk
 
 if platform.system() == "Windows":
     original_find = ctypes.util.find_library
@@ -40,12 +41,39 @@ def prepare_audio(path: str) -> str:
     return out_path
 
 
-def main(file_path: str) -> None:
-    temp_path = prepare_audio(file_path)
+def transcribe_with_whisper(temp_path: str) -> str:
     model = whisper.load_model("base")
     result = model.transcribe(temp_path)
-    os.remove(temp_path)
-    print(result["text"])
+    return result["text"]
+
+
+def transcribe_with_azure(temp_path: str) -> str:
+    key = os.getenv("AZURE_SPEECH_KEY")
+    region = os.getenv("AZURE_SPEECH_REGION")
+    if not key or not region:
+        raise RuntimeError("Azure Speech credentials not provided")
+    speech_config = speechsdk.SpeechConfig(subscription=key, region=region)
+    speech_config.speech_recognition_language = "en-US"
+    audio_config = speechsdk.audio.AudioConfig(filename=temp_path)
+    recognizer = speechsdk.SpeechRecognizer(
+        speech_config=speech_config, audio_config=audio_config
+    )
+    result = recognizer.recognize_once()
+    if result.reason == speechsdk.ResultReason.RecognizedSpeech:
+        return result.text
+    raise RuntimeError(f"Azure STT error: {result.reason}")
+
+
+def main(file_path: str) -> None:
+    temp_path = prepare_audio(file_path)
+    try:
+        if os.getenv("AZURE_SPEECH_KEY") and os.getenv("AZURE_SPEECH_REGION"):
+            text = transcribe_with_azure(temp_path)
+        else:
+            text = transcribe_with_whisper(temp_path)
+        print(text)
+    finally:
+        os.remove(temp_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add Azure Speech dependencies
- allow `transcribe.py` to use Azure Speech to Text when credentials are set
- document new `AZURE_SPEECH_KEY` and `AZURE_SPEECH_REGION` variables
- mention Azure Speech in logging and deployment docs

## Testing
- `python3 -m py_compile transcribe.py`
- `npm --prefix frontend run lint`

------
https://chatgpt.com/codex/tasks/task_e_688a2852386c832faa008ebdafadedc1