### PR TITLE
Use Azure environment variables over local .env

### DIFF
--- a/BACKEND.md
+++ b/BACKEND.md
@@ -33,7 +33,7 @@ DB_NAME=snacktrack
 PORT=4000
 ```
 
-If a `.env` file is present these values are loaded with `dotenv`.
+If a `.env` file is present these values are loaded with `dotenv` during local development. When `WEBSITE_INSTANCE_ID` is defined (the case on Azure Web Apps) the server skips loading `.env` files and relies solely on environment variables provided by the platform.
 When connecting to a hosted database (e.g. Render or Heroku), provide the host, port, username and password from your provider. TLS is automatically enabled for any host that is not `localhost`.
 
 Future API routes should be added to `server.js`.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The server automatically creates an `uploads` folder for media files if it does 
 
 ### Environment Variables
 
-Create a `.env` file in the project root for local development and define the following variables. In production, set them in your hosting provider's configuration (for Azure use **App Settings**):
+Create a `.env` file in the project root for local development and define the following variables. In production, set them in your hosting provider's configuration (for Azure use **App Settings**). When running on Azure (detected via `WEBSITE_INSTANCE_ID`) the server ignores `.env` files and only uses values from the environment:
 
 VITE_JWT_SECRET=<your secret key>
 VITE_API_BASE_URL=<deployed backend URL>

--- a/db.js
+++ b/db.js
@@ -7,11 +7,16 @@ import { fileURLToPath } from 'url';
 import dotenv from 'dotenv';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const envPath = path.join(__dirname, '.env');
-if (fs.existsSync(envPath)) {
-  dotenv.config({ path: envPath });
-} else {
-  dotenv.config();
+// Only load environment variables from a .env file when not running on Azure
+// (detected via the WEBSITE_INSTANCE_ID variable). Azure injects configuration
+// directly into process.env so loading a file could override those values.
+if (!process.env.WEBSITE_INSTANCE_ID) {
+  const envPath = path.join(__dirname, '.env');
+  if (fs.existsSync(envPath)) {
+    dotenv.config({ path: envPath });
+  } else {
+    dotenv.config();
+  }
 }
 
 const isLocal =

--- a/server.js
+++ b/server.js
@@ -11,11 +11,16 @@ import { BlobServiceClient } from '@azure/storage-blob';
 import { pool, initDb } from './db.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const envPath = path.join(__dirname, '.env');
-if (fs.existsSync(envPath)) {
-  dotenv.config({ path: envPath });
-} else {
-  dotenv.config();
+// Load .env only when not running on Azure. When deployed on Azure Web Apps the
+// environment variables are provided via App Settings and WEBSITE_INSTANCE_ID is
+// defined.
+if (!process.env.WEBSITE_INSTANCE_ID) {
+  const envPath = path.join(__dirname, '.env');
+  if (fs.existsSync(envPath)) {
+    dotenv.config({ path: envPath });
+  } else {
+    dotenv.config();
+  }
 }
 
 const blobServiceClient = process.env.AZURE_STORAGE_CONNECTION_STRING


### PR DESCRIPTION
## Summary
- avoid loading `.env` on Azure by checking `WEBSITE_INSTANCE_ID`
- document that `.env` is ignored when running on Azure

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a786dc0d8832f93bed10e3c8383ee