### PR TITLE
Add mobile build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,28 @@ The `/api/transcribe` endpoint depends on Python 3, `ffmpeg` and either the
 Speech to Text; otherwise it falls back to Whisper. Ensure these dependencies are
 installed (run `python setup_env.py`) before deploying the backend. Without
 them the transcription step will fail and AI Capture will display an error.
+
+### Building a mobile app
+
+This project already includes [Capacitor](https://capacitorjs.com/) so the
+frontend can be packaged as a native Android or iOS application. To generate the
+mobile projects you will need Android Studio (for APKs) and Xcode (for iOS).
+
+Run the following commands from the project root:
+
+```sh
+# Install Capacitor's native projects (only once)
+npx cap add android
+npx cap add ios
+
+# Build the web assets and copy them into the native projects
+npm run build
+npx cap sync
+
+# Open the projects in their respective IDEs
+npx cap open android   # opens Android Studio
+npx cap open ios       # opens Xcode
+```
+
+From Android Studio or Xcode you can build release versions and generate the APK
+or iOS app for distribution.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "lint": "npm --prefix frontend run lint",
     "preview": "npm --prefix frontend run preview",
     "start": "node server.js",
-    "dev:backend": "nodemon server.js"
+    "dev:backend": "nodemon server.js",
+    "mobile:sync": "npm run build && npx cap sync --config frontend/capacitor.config.ts",
+    "mobile:android": "npm run mobile:sync && npx cap open android --config frontend/capacitor.config.ts",
+    "mobile:ios": "npm run mobile:sync && npx cap open ios --config frontend/capacitor.config.ts"
   },
   "dependencies": {
     "@azure/storage-blob": "^12.15.0",


### PR DESCRIPTION
## Summary
- document how to build Android/iOS apps via Capacitor
- add npm scripts to package mobile builds

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688a805cbeb8832fa51657b4e2436562