### PR TITLE
Fix API base URL usage for file upload and transcription

### DIFF
--- a/frontend/src/lib/azure-ai.ts
+++ b/frontend/src/lib/azure-ai.ts
@@ -1,3 +1,4 @@
+import { buildUrl } from './local-db';
 
 export interface AzureAIAnalysis {
   transcription?: string;
@@ -23,7 +24,7 @@ export class AzureAIService {
     const formData = new FormData();
     formData.append('audio', audioBlob);
 
-    const response = await fetch('/api/transcribe', {
+    const response = await fetch(buildUrl('/transcribe'), {
       method: 'POST',
       body: formData,
     });

--- a/frontend/src/lib/local-db.ts
+++ b/frontend/src/lib/local-db.ts
@@ -50,9 +50,9 @@ function toCamelCase(obj: any): any {
   return obj;
 }
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
+export const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
 
-function buildUrl(endpoint: string): string {
+export function buildUrl(endpoint: string): string {
   if (!API_BASE) return `/api${endpoint}`;
   let base = API_BASE.replace(/\/$/, '');
   if (base.endsWith('/api')) {

--- a/frontend/src/lib/local-storage.ts
+++ b/frontend/src/lib/local-storage.ts
@@ -5,8 +5,10 @@ export interface UploadResult {
   error?: string;
 }
 
+import { buildUrl } from './local-db';
+
 export class LocalStorageService {
-  private uploadEndpoint = '/api/upload';
+  private uploadEndpoint = buildUrl('/upload');
 
   async uploadFile(file: File): Promise<UploadResult> {
     const formData = new FormData();


### PR DESCRIPTION
## Summary
- export a shared `buildUrl` helper
- use `buildUrl` for `/api/transcribe` and `/api/upload`

## Testing
- `npm run lint`
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_688a8021ec38832fa744235a10faed05