### PR TITLE
Improve text analytics handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ AZURE_AUDIO_CONTAINER=audio-logs
 AZURE_MEDIA_CONTAINER=media-logs
 AZURE_SPEECH_KEY=<your speech key>
 AZURE_SPEECH_REGION=<your speech region>
+AZURE_TEXT_ANALYTICS_ENDPOINT=<your text analytics endpoint>
+AZURE_TEXT_ANALYTICS_KEY=<your text analytics api key>
 ```
 
 `VITE_API_BASE_URL` is optional when the frontend and backend are served from the same domain. Set it to your backend URL when running the frontend locally against a remote API.
@@ -118,6 +120,11 @@ The `/api/transcribe` endpoint relies on `ffmpeg` and the
 Speech to Text to process uploaded audio. Ensure these dependencies are
 installed before deploying the backend. Without them the transcription step will
 fail and AI Capture will display an error.
+
+The `/api/analyze` endpoint runs Azure Text Analytics on a block of text and
+returns its sentiment and key phrases. Provide
+`AZURE_TEXT_ANALYTICS_ENDPOINT` and `AZURE_TEXT_ANALYTICS_KEY` to enable this
+feature.
 
 ### Building a mobile app
 

--- a/frontend/src/lib/azure-ai.ts
+++ b/frontend/src/lib/azure-ai.ts
@@ -3,7 +3,7 @@ import { buildUrl } from './local-db';
 export interface AzureAIAnalysis {
   transcription?: string;
   detectedProducts?: string[];
-  sentiment?: 'positive' | 'negative' | 'neutral';
+  sentiment?: 'positive' | 'negative' | 'neutral' | 'mixed';
   confidence?: number;
   emotions?: string[];
   brands?: string[];
@@ -50,77 +50,31 @@ export class AzureAIService {
     mediaType: 'audio' | 'video',
     onProgress?: (progress: number) => void
   ): Promise<AzureAIAnalysis> {
-    // Simulate AI analysis based on transcription
-    // In a real implementation, you would use Azure Text Analytics, Custom Vision, etc.
-
-    return new Promise((resolve) => {
-      let progress = 0;
-      const interval = setInterval(() => {
-        progress += 20;
-        onProgress?.(Math.min(progress, 100));
-        if (progress >= 100) {
-          clearInterval(interval);
-
-          const productKeywords = [
-            'coca-cola',
-            'pepsi',
-            'burger',
-            'pizza',
-            'coffee',
-            'tea',
-            'sandwich',
-            'chips'
-          ];
-          const brandKeywords = ['mcdonald', 'kfc', 'starbucks', 'subway', 'dominos'];
-          const categoryKeywords = ['beverage', 'snack', 'fast food', 'coffee', 'dessert'];
-
-          const detectedProducts = productKeywords.filter((keyword) =>
-            transcription.toLowerCase().includes(keyword)
-          );
-
-          const brands = brandKeywords.filter((keyword) =>
-            transcription.toLowerCase().includes(keyword)
-          );
-
-          const categories = categoryKeywords.filter((keyword) =>
-            transcription.toLowerCase().includes(keyword)
-          );
-
-          // Simple sentiment analysis
-          const positiveWords = ['good', 'great', 'delicious', 'amazing', 'love', 'excellent'];
-          const negativeWords = ['bad', 'terrible', 'awful', 'hate', 'disgusting'];
-
-          const positiveCount = positiveWords.filter((word) =>
-            transcription.toLowerCase().includes(word)
-          ).length;
-
-          const negativeCount = negativeWords.filter((word) =>
-            transcription.toLowerCase().includes(word)
-          ).length;
-
-          let sentiment: 'positive' | 'negative' | 'neutral' = 'neutral';
-          if (positiveCount > negativeCount) sentiment = 'positive';
-          else if (negativeCount > positiveCount) sentiment = 'negative';
-
-          resolve({
-            transcription,
-            detectedProducts,
-            sentiment,
-            confidence: Math.random() * 0.3 + 0.7, // 70-100% confidence
-            emotions:
-              sentiment === 'positive'
-                ? ['happy', 'satisfied']
-                : sentiment === 'negative'
-                ? ['disappointed']
-                : ['neutral'],
-            brands,
-            categories,
-            estimatedSpend: '$' + (Math.random() * 20 + 5).toFixed(2),
-            location: 'Detected from audio context'
-          });
-        }
-      }, 400);
+    const response = await fetch(buildUrl('/analyze'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: transcription })
     });
+
+    if (!response.ok) {
+      let msg = 'Analysis failed';
+      try {
+        const err = await response.json();
+        msg = err.message || msg;
+      } catch {
+        // ignore parse errors
+      }
+      throw new Error(msg);
+    }
+
+    const data: { sentiment: string; confidence?: number; categories?: string[] } = await response.json();
+    onProgress?.(100);
+    return {
+      transcription,
+      sentiment: data.sentiment as 'positive' | 'negative' | 'neutral' | 'mixed',
+      confidence: data.confidence,
+      categories: data.categories
+    };
   }
 
   async analyzeImage(imageBlob: Blob): Promise<AzureAIAnalysis> {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
     "zod": "^3.23.8",
-    "microsoft-cognitiveservices-speech-sdk": "^1.45.0"
+    "microsoft-cognitiveservices-speech-sdk": "^1.45.0",
+    "@azure/ai-text-analytics": "^5.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'url';
 import dotenv from 'dotenv';
 import cors from 'cors';
 import { BlobServiceClient } from '@azure/storage-blob';
+import { TextAnalyticsClient, AzureKeyCredential } from '@azure/ai-text-analytics';
 import { pool, initDb } from './db.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -38,6 +39,14 @@ const mediaContainer =
   blobServiceClient?.getContainerClient(
     process.env.AZURE_MEDIA_CONTAINER
   );
+
+const textAnalyticsClient =
+  process.env.AZURE_TEXT_ANALYTICS_ENDPOINT && process.env.AZURE_TEXT_ANALYTICS_KEY
+    ? new TextAnalyticsClient(
+        process.env.AZURE_TEXT_ANALYTICS_ENDPOINT,
+        new AzureKeyCredential(process.env.AZURE_TEXT_ANALYTICS_KEY)
+      )
+    : null;
 
 const app = express();
 const PORT = process.env.PORT || 4000;
@@ -176,6 +185,35 @@ app.post('/api/transcribe', upload.single('audio'), async (req, res) => {
     console.error('Transcription failed', err);
     fs.unlink(req.file.path, () => {});
     res.status(500).json({ message: 'Transcription failed' });
+  }
+});
+
+app.post('/api/analyze', async (req, res) => {
+  const { text } = req.body;
+  if (!text) return res.status(400).json({ message: 'No text provided' });
+  if (!textAnalyticsClient) {
+    return res.status(500).json({ message: 'Text analytics not configured' });
+  }
+  try {
+    const [sentimentResult] = await textAnalyticsClient.analyzeSentiment([text]);
+    const [phrasesResult] = await textAnalyticsClient.extractKeyPhrases([text]);
+    const { positive, neutral, negative } = sentimentResult.confidenceScores;
+    const confidenceMap = {
+      positive,
+      neutral,
+      negative,
+    };
+    const confidence =
+      confidenceMap[sentimentResult.sentiment] ??
+      Math.max(positive, neutral, negative);
+    res.json({
+      sentiment: sentimentResult.sentiment,
+      confidence,
+      categories: phrasesResult.keyPhrases,
+    });
+  } catch (err) {
+    console.error('Text analysis failed', err);
+    res.status(500).json({ message: 'Text analysis failed' });
   }
 });
 


### PR DESCRIPTION
## Summary
- document `/api/analyze` usage
- allow `mixed` sentiment in AzureAI client
- compute text analytics confidence correctly

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ba8c587c8832f986a22916be879a3