### PR TITLE
feat: Migrate from Azure AI to Whisper and Natural

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,6 @@ Create a `.env` file in the project root for local development and define the fo
 
 VITE_JWT_SECRET=<your secret key>
 VITE_API_BASE_URL=<deployed backend URL>
-# Frontend access to Azure Speech
-VITE_AZURE_SPEECH_KEY=<your speech key>
-VITE_AZURE_REGION=<your speech region>
 # Use only the domain, not the `/api` path. The app will automatically
 # append `/api` when contacting the backend.
 CORS_ORIGIN=<allowed domains>
@@ -57,10 +54,7 @@ DB_NAME=snacktrack
 AZURE_STORAGE_CONNECTION_STRING=<your connection string>
 AZURE_AUDIO_CONTAINER=audio-logs
 AZURE_MEDIA_CONTAINER=media-logs
-AZURE_SPEECH_KEY=<your speech key>
-AZURE_SPEECH_REGION=<your speech region>
-AZURE_TEXT_ANALYTICS_ENDPOINT=<your text analytics endpoint>
-AZURE_TEXT_ANALYTICS_KEY=<your text analytics api key>
+HF_TOKEN=<your hugging face api token>
 ```
 
 `VITE_API_BASE_URL` is optional when the frontend and backend are served from the same domain. Set it to your backend URL when running the frontend locally against a remote API.
@@ -108,34 +102,20 @@ This project is built with:
 
 ### Logging meals
 
-On the log consumption page you can switch between **Manual Entry** and **AI Capture**. Manual entry only shows the meal form, while AI Capture also records audio or video which is transcribed using Azure Speech to Text when credentials are provided (otherwise Whisper is used).
-When `VITE_AZURE_SPEECH_KEY` and `VITE_AZURE_REGION` are set the browser uploads recordings directly to Azure, bypassing the `/api/transcribe` route.
-Audio recordings are saved as `.wav` for maximum compatibility with Azure Speech.
+On the log consumption page you can switch between **Manual Entry** and **AI Capture**. Manual entry only shows the meal form, while AI Capture also records audio or video.
+The recorded audio is sent to the backend `/api/transcribe` endpoint, which uses the Hugging Face Inference API with the Whisper model for transcription. The backend must be configured with an `HF_TOKEN` for this to work. You can generate a free token from your Hugging Face account settings.
+Audio recordings are saved as `.wav` for maximum compatibility.
 ### Deploying to Azure
 
 You can publish the frontend using **Azure Static Web Apps** and deploy the Express backend to **Azure Web App**. Configure your preferred CI/CD solution or deploy manually as needed.
 
 Requests from the static site to `/api` are proxied to the backend using `frontend/staticwebapp.config.json`. Update this file with your backend domain so the frontend can communicate with the API once deployed. If the frontend and backend appear disconnected, verify that this file points to your deployed backend's URL.
 
-The `/api/transcribe` endpoint now sends uploaded audio directly to the Azure
-Speech Service. When `AZURE_SPEECH_KEY` and `AZURE_SPEECH_REGION` are provided
-the server forwards the file to Azure and returns the recognized text. If the
-request fails the server returns the detailed error message from Azure so you
-can diagnose configuration issues.
 
-The `/api/analyze` endpoint runs Azure Text Analytics on a block of text and
-returns its sentiment and key phrases. Provide
-`AZURE_TEXT_ANALYTICS_ENDPOINT` and `AZURE_TEXT_ANALYTICS_KEY` to enable this
-feature.
+The `/api/analyze` endpoint uses the `natural` library to perform sentiment analysis and keyword extraction on a block of text. This runs locally on the backend and requires no external API keys.
 
 When transcription fails the server now returns the underlying error message in
-the response to help diagnose issues such as missing `ffmpeg` or invalid Azure
-credentials.
-
-The `/api/analyze` endpoint runs Azure Text Analytics on a block of text and
-returns its sentiment and key phrases. Provide
-`AZURE_TEXT_ANALYTICS_ENDPOINT` and `AZURE_TEXT_ANALYTICS_KEY` to enable this
-feature.
+the response to help diagnose issues such as missing `ffmpeg` or an invalid Hugging Face token.
 
 ### Building a mobile app
 

--- a/frontend/staticwebapp.config.json
+++ b/frontend/staticwebapp.config.json
@@ -2,17 +2,11 @@
   "routes": [
     {
       "route": "/api/*",
-      "methods": [
-        "GET",
-        "POST",
-        "OPTIONS"
-      ],
-      "rewrite": "https://snacksappbackendv2b-b0erbpa2dmh6brg0.southafricanorth-01.azurewebsites.net/api/:path*"
+      "forward": "https://snacksappbackendv2b-b0erbpa2dmh6brg0.southafricanorth-01.azurewebsites.net/api/:path*"
     }
   ],
   "globalHeaders": {
     "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
     "Access-Control-Allow-Headers": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "lovable-tagger": "^1.1.8",
     "lucide-react": "^0.462.0",
     "multer": "^2.0.2",
+    "natural": "^8.1.0",
     "pg": "^8.11.5",
     "react": "^18.3.1",
     "react-activity-calendar": "^2.7.13",
@@ -75,8 +76,7 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
-    "zod": "^3.23.8",
-    "@azure/ai-text-analytics": "^5.1.0"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",


### PR DESCRIPTION
This commit completes the full migration of AI services from Azure to open-source and community-driven alternatives. This change removes dependencies on Azure AI, simplifies the required configuration, and resolves persistent platform-related issues.

- **Transcription:** The `/api/transcribe` endpoint has been refactored to use the Hugging Face Inference API for the `openai/whisper-large-v3` model. This replaces the Azure Speech to Text service.

- **Text Analysis:** The `/api/analyze` endpoint has been refactored to use the `natural` npm package. This library now provides both sentiment analysis and keyword extraction (for categories), running locally on the backend. This replaces the Azure Text Analytics service.

- **Configuration:** All `AZURE_SPEECH_*` and `AZURE_TEXT_ANALYTICS_*` environment variables have been removed. The only new variable required is `HF_TOKEN` for Hugging Face API authentication.

- **Dependencies:** The `@azure/ai-text-analytics` package has been removed.

- **Documentation:** The `README.md` has been thoroughly updated to reflect all of these changes, providing new instructions and removing all references to the deprecated Azure AI services.