### PR TITLE
feat: integrate azure speech and text analytics

### DIFF
--- a/AZURE_DEPLOYMENT.md
+++ b/AZURE_DEPLOYMENT.md
@@ -56,7 +56,10 @@ Next, we'll deploy the Node.js backend.
         -   `DB_USER`: Your PostgreSQL admin username.
         -   `DB_PASSWORD`: Your PostgreSQL admin password.
         -   `DB_NAME`: `snacktrack`.
-        -   `HF_TOKEN`: Your Hugging Face API token.
+        -   `AZURE_SPEECH_KEY`: Your Azure Speech resource key.
+        -   `AZURE_SPEECH_REGION`: Region of your Azure Speech resource.
+        -   `AZURE_LANGUAGE_KEY`: Your Azure AI Language resource key.
+        -   `AZURE_LANGUAGE_ENDPOINT`: Endpoint of your Azure AI Language resource.
         -   `AZURE_STORAGE_CONNECTION_STRING` (Optional): Your Azure Storage connection string.
         -   `AZURE_AUDIO_CONTAINER` (Optional): `audio-logs`.
         -   `AZURE_MEDIA_CONTAINER` (Optional): `media-logs`.

--- a/BACKEND.md
+++ b/BACKEND.md
@@ -13,18 +13,18 @@ npm start
 
 The server will start on the port specified by the `PORT` environment variable (defaults to `4000`).
 
-## Transcription Service
+## Transcription and Analysis
 
-The backend uses the Hugging Face Inference API for audio transcription. Specifically, it sends audio files to a speech-to-text model and receives the transcribed text.
+The backend uses **Azure Speech Services** to convert uploaded audio into text and **Azure AI Text Analytics** to evaluate the
+transcription for sentiment and key phrases. Create these resources in the Azure Portal and provide their credentials via
+environment variables as shown below.
 
-To use this service, you need a Hugging Face API token.
+The server exposes two routes for this workflow:
 
-### Getting a Hugging Face API Token
+- `POST /api/transcribe` – accepts an audio file and returns the transcript using Azure Speech Services. Requires `AZURE_SPEECH_KEY` and `AZURE_SPEECH_REGION`.
+- `POST /api/analyze` – accepts raw text and returns sentiment and key phrases from Azure AI Text Analytics. Requires `AZURE_LANGUAGE_KEY` and `AZURE_LANGUAGE_ENDPOINT`.
 
-1.  Create a free account on [Hugging Face](https://huggingface.co/join).
-2.  Navigate to your profile settings: `https://huggingface.co/settings/tokens`.
-3.  Generate a new **User Access Token**. A `read`-only token is sufficient for this service.
-4.  Copy the token. You will use this for the `HF_TOKEN` environment variable.
+Hugging Face Whisper and the local `natural` package are no longer used, so no `HF_TOKEN` is needed. Without valid Azure credentials calls to these endpoints will fail, preventing local testing unless the Azure resources exist.
 
 ## Environment Variables
 
@@ -37,12 +37,14 @@ For local development, create a `.env` file in the project root. In a production
 -   `DB_USER`: The username for your PostgreSQL database.
 -   `DB_PASSWORD`: The password for your PostgreSQL database.
 -   `DB_NAME`: The name of your PostgreSQL database.
--   `HF_TOKEN`: Your Hugging Face API token.
+-   `AZURE_SPEECH_KEY`: Key for your Azure Speech resource.
+-   `AZURE_SPEECH_REGION`: Region for your Azure Speech resource.
+-   `AZURE_LANGUAGE_KEY`: Key for your Azure AI Language resource.
+-   `AZURE_LANGUAGE_ENDPOINT`: Endpoint URL for your Azure AI Language resource.
 
 ### Optional Variables
 
 -   `PORT`: The port for the backend server to listen on (defaults to `4000`).
--   `HF_MODEL`: The Hugging Face model to use for transcription (defaults to `openai/whisper-large-v3`). You can specify any other compatible model.
 -   `AZURE_STORAGE_CONNECTION_STRING`: If you want to store uploaded files in Azure Blob Storage, provide the connection string here.
 -   `AZURE_AUDIO_CONTAINER`: The name of the Azure Blob Storage container for audio files.
 -   `AZURE_MEDIA_CONTAINER`: The name of the Azure Blob Storage container for media files.
@@ -57,8 +59,10 @@ DB_USER=snackuser
 DB_PASSWORD=snackpass
 DB_NAME=snacktrack
 PORT=4000
-HF_TOKEN=your_hugging_face_token_here
-# HF_MODEL=openai/whisper-base
+AZURE_SPEECH_KEY=your_speech_key
+AZURE_SPEECH_REGION=your_speech_region
+AZURE_LANGUAGE_KEY=your_language_key
+AZURE_LANGUAGE_ENDPOINT=https://your-language-resource.cognitiveservices.azure.com/
 ```
 
 The server automatically loads variables from the `.env` file during local development. When deployed to Azure, it will use the environment variables configured in the App Settings.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "mobile:ios": "npm run mobile:sync && npx cap open ios --config frontend/capacitor.config.ts"
   },
   "dependencies": {
+    "@azure/ai-text-analytics": "^5.1.0",
     "@azure/storage-blob": "^12.15.0",
     "@capacitor/android": "^7.4.2",
     "@capacitor/cli": "^7.4.2",
@@ -61,8 +62,8 @@
     "input-otp": "^1.2.4",
     "lovable-tagger": "^1.1.8",
     "lucide-react": "^0.462.0",
+    "microsoft-cognitiveservices-speech-sdk": "^1.45.0",
     "multer": "^2.0.2",
-    "natural": "^8.1.0",
     "pg": "^8.11.5",
     "react": "^18.3.1",
     "react-activity-calendar": "^2.7.13",


### PR DESCRIPTION
## Summary
- replace Hugging Face transcription with Azure Speech Services
- analyze transcriptions with Azure AI Text Analytics
- document Azure credentials for backend deployment
- clarify Azure service requirements in README and BACKEND docs
- ensure JSON request bodies are parsed so `/api/analyze` receives text

## Testing
- `npm install`
- `npm test` *(fails: Missing script: "test")*
- `node --check server.js`
- `node server.js` *(fails: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_689322b7dca0832f9da6cdd67e599c56