### PR TITLE
Add support page with Calgary office map

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import Rewards from "./pages/Rewards";
 import AdminDashboard from "./pages/AdminDashboard";
 import Profile from "./pages/Profile";
 import TermsAndConditions from "./pages/TermsAndConditions";
+import Support from "./pages/Support";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -33,6 +34,7 @@ const App = () => (
           <Route path="/admin" element={<AdminDashboard />} />
           <Route path="/profile" element={<Profile />} />
           <Route path="/terms" element={<TermsAndConditions />} />
+          <Route path="/support" element={<Support />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </BrowserRouter>

--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -1,0 +1,34 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+const Support = () => {
+  return (
+    <div className="min-h-screen gradient-secondary py-8">
+      <div className="container mx-auto px-4 max-w-4xl">
+        <Card className="glass-card hover-glow">
+          <CardHeader>
+            <CardTitle className="text-3xl font-bold text-gradient text-center">
+              Support
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <p className="text-gray-700 text-center">
+              iBUILD’s office address is:<br />
+              4960 13 ST SW Calgary, AB T2G 5M9
+            </p>
+            <div className="w-full h-96">
+              <iframe
+                title="iBUILD office location"
+                className="w-full h-full rounded-md"
+                loading="lazy"
+                allowFullScreen
+                src="https://www.google.com/maps?q=4960+13+ST+SW+Calgary,+AB+T2G+5M9&z=16&output=embed"
+              />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default Support;


### PR DESCRIPTION
## Summary
- create Support page displaying iBUILD's Calgary office address and embedded Google Map marker
- register Support page route in app router

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 10 errors, 8 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ec8e0d28832fbeaf006150b926c0